### PR TITLE
開発用にDBコンテナを設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coias-front-app
 coias-back-app
+/database

--- a/doc/開発用環境構築.md
+++ b/doc/開発用環境構築.md
@@ -95,6 +95,31 @@ docker network ls
 docker network rm ネットワークID
 ```
 
+## データベース
+
+docker-composeによりMariaDBがセットアップされる。リセットしたい場合は `./database` を削除する。
+
+接続情報は次のようになる。
+
+|||
+|--|--|
+|host|db|
+|db|COIAS|
+|user|dataHandler|
+|password|password|
+
+localhostからのrootはパスワードなしで接続できる。
+
+MySQLからのダンプファイルを与える場合は次のようにする。
+
+```bash
+sed \
+      -e 's/utf8mb4_0900_ai_ci/utf8mb4_unicode_ci/g' \
+      -e 's/CHARSET=utf8mb4/CHARSET=utf8mb4/g' \
+      ~/Desktop/test_COIASdb_20230131.sql | \
+      docker exec -i coias-db-dev-container mysql -u root
+```
+
 ## デバック
 
 coias-back-appではvscodeの「実行とデバック」からFastAPIの起動とデバックができる。  

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,18 @@ services:
       - nginx_tmp_images:/opt/tmp_images
       - coias_hsc:/root/.coias
 
+  db:
+    container_name: coias-db-dev-container
+    image: 'mariadb:10'
+    platform: linux/x86_64
+    volumes:
+      - ./database:/var/lib/mysql:delegated
+    environment:
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes'
+      MARIADB_DATABASE: COIAS
+      MARIADB_USER: dataHandler
+      MARIADB_PASSWORD: password
+
   imagehost-dev-app:
     image: "nginx:latest"
     ports:


### PR DESCRIPTION
開発時用のDBコンテナの設定を追加。
必要なさそうだったらそのままクローズしてください。